### PR TITLE
Add `woocommerce_extensions_init`

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -166,6 +166,7 @@ final class WooCommerce {
 	private function init_hooks() {
 		register_activation_hook( WC_PLUGIN_FILE, array( 'WC_Install', 'install' ) );
 		register_shutdown_function( array( $this, 'log_errors' ) );
+		add_action( 'plugins_loaded', array( $this, 'extensions_init' ), 20 );
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
 		add_action( 'init', array( $this, 'init' ), 0 );
@@ -196,6 +197,15 @@ final class WooCommerce {
 		}
 	}
 
+	/**
+	 * Launch WooCommerce-dependent extensions.
+	 *
+	 * @since 3.6.0
+	 */
+	public function extensions_init() {
+		do_action( 'woocommerce_extensions_init' );
+	}
+	
 	/**
 	 * Define WC Constants.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As a follow up to https://github.com/woocommerce/woocommerce/pull/21525 which deprecates the `woocommerce_loaded` hook, this proposes a new hook `woocommerce_extensions_init` which should fire reliably once all plugins are loaded regardless of what the extensions' folder/name is. 

### How to test the changes in this Pull Request:

1.  Add the following zzz-woocommerce-extension.php plugin to `wp-content/plugins/zzz-woocommerce-extension/zzz-woocommerce-extension.php` : 
```
<?php
/*
 * Plugin Name: ZZZ WooCommerce Extension
 * Description: WooCommerce extension activation test.
 * Version: 1.0
 * Author: Kathy Darling
 * Author URI: http://kathyisawesome.com
 *
 * License: GNU General Public License v3.0
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
 *
 */

error_log( 'zzz woo extension is loaded' );

/**
 * Should only run if WooCommerce is active.
 */
function zzz_test_new_hook() {
    if( defined( 'WC_VERSION' ) ) {
        error_log( 'WooCommerce is active and the version is ' . WC_VERSION . ' and this hook is ' . current_action() );
    } else {
        error_log( 'WooCommerce is NOT active and this hook is ' . current_action() );
    }
}
add_action( 'woocommerce_extensions_init', 'zzz_test_new_hook' );
add_action( 'woocommerce_loaded', 'zzz_test_new_hook' );
```


2. Enable `WP_DEBUG_LOG`.
3. Activate the plugin.
4. Check the error log, which should show both:
the deprecated notice for `woocommerce_loaded` 
and `WooCommerce is active and the version is 3.5.0 and this hook is woocommerce_extensions_init`, 
but neither `WooCommerce is active and the version is 3.5.0 and this hook is woocommerce_loaded` nor `WooCommerce is NOT active and this hook is woocommerce_loaded`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Trigger woocommerce_extensions_init hook on plugins_loaded for initializing WooCommerce Extensions
